### PR TITLE
Updating provisionCluster.sh to setup workload identity

### DIFF
--- a/flowAgentPatch.yaml
+++ b/flowAgentPatch.yaml
@@ -1,0 +1,5 @@
+spec:
+  template:
+    spec:
+      serviceAccountName: gcloud-sa
+      automountServiceAccountToken: false

--- a/provisionCluster.sh
+++ b/provisionCluster.sh
@@ -8,7 +8,6 @@ gcloud beta container clusters create $1 \
 --issue-client-certificate \
 --machine-type=n1-standard-8 \
 --num-nodes=1 \
---password=cloudbeesdemoenv \
 --region=$2 \
 --username=admin \
 --verbosity=none \
@@ -125,6 +124,10 @@ until [ "$FLOW_SERVER_STATUS" == "$TARGET_STATUS" ]; do
   sleep 15;
   FLOW_SERVER_STATUS=$(kubectl exec $FLOW_SERVER_POD -- /opt/cbflow/health-check);
 done
+
+# Patching agent deployment
+kubectl patch deployment flow-bound-agent -p "$(cat flowAgentPatch.yaml)"
+
 
 # Create Users and resourcePools
 echo '----> Adding users to Flow'

--- a/provisionCluster.sh
+++ b/provisionCluster.sh
@@ -12,7 +12,7 @@ gcloud container clusters create $1 \
 --region=$2 \
 --username=admin \
 --verbosity=none \
---scopes=cloud-platform
+--scopes=cloud-platform \
 --identity-namespace=$3.svc.id.goog
 
 # with the cluster provisioned, get its credentials and set up kubectl

--- a/provisionCluster.sh
+++ b/provisionCluster.sh
@@ -28,14 +28,14 @@ kubectl create clusterrolebinding tiller \
   --serviceaccount=kube-system:tiller
 
 # kubectl rollout status deployment tiller-deploy --namespace kube-system 
-sleep 120
+# sleep 120
 
 echo '----> Initializing Helm'
 helm init --wait --service-account tiller
 helm repo add cloudbees https://charts.cloudbees.com/public/cloudbees
 helm repo update
 
-sleep 120
+# sleep 120
 
 echo '----> Creating the nginx namespace'
 kubectl create namespace nginx 

--- a/provisionCluster.sh
+++ b/provisionCluster.sh
@@ -3,7 +3,7 @@
 echo '----> Provisioning cluster '$1' in region '$2' in project '$3'.'
 
 # provision a GKE cluster
-gcloud container clusters create $1 \
+gcloud beta container clusters create $1 \
 --cluster-version=1.13.12-gke.8 \
 --issue-client-certificate \
 --machine-type=n1-standard-8 \


### PR DESCRIPTION
[Workload identity](https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity) allows you to run gcloud commands without needing to worry about credentials files.

This does require creating a service account in GCP IAM called gcloud-sa which has Kubernetes access. 

Also, I've modified this script to use the project flag as a parameter ($3) so it's easier to use & test in different projects.